### PR TITLE
Set type:module in package.json for full ES6/ESModules compatability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "jest",
     "coverage": "jest --coverage"


### PR DESCRIPTION
Since this package is ES6 and uses ESModules `import`/`export`, let's set
`{"type": "module"}` in `package.json`. As per Node.js docs:
https://nodejs.org/api/packages.html#packages_determining_module_system
Fixes a bug in my own project.
Thanks!